### PR TITLE
Select with {key: value} style options

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "uglify-js": "^3.0.9"
   },
   "dependencies": {
-    "coffee-script": "~1.7.1",
+    "coffeescript": "^2",
     "commander": "^2.9.0",
     "jison": "^0.4.17",
     "jison-lex": "^0.3.4",

--- a/script/coverage
+++ b/script/coverage
@@ -3,7 +3,7 @@ set -e
 
 node_modules/.bin/istanbul cover \
   node_modules/.bin/_mocha -- \
-    --compilers coffee:coffee-script \
-    --require coffee-script/register \
+    --compilers coffee:coffeescript \
+    --require coffeescript/register \
     --reporter spec \
     --require test/helper.coffee

--- a/script/test
+++ b/script/test
@@ -5,8 +5,8 @@ script/prepublish
 
 node_modules/.bin/mocha \
   --expose-gc \
-  --compilers coffee:coffee-script \
+  --compilers coffee:coffeescript \
   --reporter spec \
-  --require 'coffee-script/register' \
+  --require 'coffeescript/register' \
   --require test/helper.coffee \
   "$@"

--- a/source/cli.coffee
+++ b/source/cli.coffee
@@ -2,7 +2,7 @@ fs = require "fs"
 stdin = require "stdin"
 compile = require '../dist/compiler'
 wrench = require "wrench"
-CoffeeScript = require "coffee-script"
+CoffeeScript = require "coffeescript"
 md5 = require 'md5'
 
 cli = require("commander")

--- a/source/register.coffee
+++ b/source/register.coffee
@@ -1,4 +1,4 @@
-CoffeeScript = require "coffee-script"
+CoffeeScript = require "coffeescript"
 {compile} = require "jadelet/dist/main"
 
 fs = require "fs"

--- a/source/runtime.coffee
+++ b/source/runtime.coffee
@@ -108,12 +108,11 @@ specialBindings =
         empty(element)
         element._options = values
 
-        # TODO: Handle key: value... style options
-        values.map (value, index) ->
+        makeOption = (value, key) ->
           option = createElement("option")
           option._value = value
           if isObject value
-            optionValue = value?.value or index
+            optionValue = value?.value or key
           else
             optionValue = value.toString()
 
@@ -127,9 +126,16 @@ specialBindings =
             return
 
           element.appendChild option
-          element.selectedIndex = index if value is element._value
-
+          index = value?.index or key
+          element.selectedIndex = index if (value?.value or value) is element._value
           return option
+
+        if Object::toString.call(values) is '[object Object]'
+          values = Object.keys(values).map (key, index) ->
+            makeOption {name: values[key], value: key, index}, key
+          return values
+        else
+          values.map (value, index) -> makeOption value, index
         return
       return
 

--- a/test/compiler.coffee
+++ b/test/compiler.coffee
@@ -1,6 +1,6 @@
 assert = require('assert')
 fs = require('fs')
-CoffeeScript = require "coffee-script"
+CoffeeScript = require "coffeescript"
 
 jadeletCompiler = require('../dist/compiler')
 

--- a/test/helper.coffee
+++ b/test/helper.coffee
@@ -1,6 +1,6 @@
 extend = Object.assign
 
-CoffeeScript = require "coffee-script"
+CoffeeScript = require "coffeescript"
 
 compile = require "../dist/compiler"
 Runtime = require "../dist/runtime"

--- a/test/select.coffee
+++ b/test/select.coffee
@@ -220,4 +220,65 @@ describe "SELECT", ->
       assert.equal select._value, model.value
 
   describe "with an object for options", ->
-    it "should have an option for each key"
+    template = makeTemplate """
+      select(@value @options)
+    """
+
+    it "should have an option for each key", ->
+      options = Observable
+        nap: "Napoleon"
+        bar: "Barrack"
+
+      model =
+        options: options
+        value: "bar"
+
+      select = template model
+      assert.equal select.value, "bar"
+
+    it "should add options added to the observable object", ->
+      options = Observable
+        nap: "Napoleon"
+        bar: "Barrack"
+
+      model =
+        options: options
+        value: "bar"
+
+      select = template(model)
+
+      assert.equal select.querySelectorAll("option").length, 2
+      options Object.assign {}, options(), {test: "Test"}
+      assert.equal select.querySelectorAll("option").length, 3
+
+    it "should remove options removed from the observable object", ->
+      options = Observable
+        nap: "Napoleon"
+        bar: "Barrack"
+
+      model =
+        options: options
+        value: "bar"
+
+      select = template(model)
+
+      assert.equal select.querySelectorAll("option").length, 2
+      delete options().bar
+      options Object.assign {}, options()
+      assert.equal select.querySelectorAll("option").length, 1
+
+    it "should observe the value as the value of the value options", ->
+      options = Observable
+        nap: Observable "Napoleon"
+        bar: Observable "Barrack"
+
+      model =
+        options: options
+        value: "bar"
+
+      select = template model
+      optionElements = select.querySelectorAll("option")
+
+      assert.equal optionElements[1].textContent, "Barrack"
+      options().bar "YOLO"
+      assert.equal optionElements[1].textContent, "YOLO"


### PR DESCRIPTION
This PR enables use of `key: value` style options for the `select` field. And, as a bonus, adds Coffeescript 2.

```coffeescript
template = makeTemplate """
  select(@value @options)
"""

options = Observable
  nap: "Napoleon"
  bar: "Barrack"

model =
  options: options
  value: "bar"

select = template model

assert.equal select.value, "bar"

# adding an option
options Object.assign {}, options(), {test: "Test"}
assert.equal select.querySelectorAll("option").length, 3

# deleting an option
delete options().test
options Object.assign {}, options()
assert.equal select.querySelectorAll("option").length, 2
```

Observable value

```coffeescript
template = makeTemplate """
  select(@value @options)
"""

options = Observable
  nap: Observable "Napoleon"
  bar: Observable "Barrack"

model =
  options: options
  value: "bar"

select = template model

optionElements = select.querySelectorAll("option")
assert.equal optionElements[1].textContent, "Barrack"
options().bar "YOLO"
assert.equal optionElements[1].textContent, "YOLO"
```

With the PR from [distri/observable](https://github.com/distri/observable/pull/6) adding and deleting option can be shorter:

```coffeescript
# adding an option
options.extend {test: "Test"}

# deleting an option
options.remove "test"
```

