### PR TITLE
Add support for a 'Fragment' tag

### DIFF
--- a/source/jadelet.coffee
+++ b/source/jadelet.coffee
@@ -106,7 +106,7 @@ observeAttribute = (element, context, name, value) ->
       if isEvent("on#{name}", element)
         # It doesn't make sense for events to not be bound
         bindEvent(element, name, value.bind, context)
-      else 
+      else
         bindObservable element, value, context, (newValue) ->
           if newValue? and newValue != false
             element.setAttribute name, newValue
@@ -305,6 +305,8 @@ render = (astNode, context={}, namespace) ->
 
   if namespace
     element = document.createElementNS namespace, tag
+  else if tag is "Fragment" or tag is "<>"
+    element = document.createDocumentFragment()
   else
     element = document.createElement tag
   # We populate the content first so that value binding for `select` tags


### PR DESCRIPTION
This PR adds support for a [fragments](https://developer.mozilla.org/en-US/docs/Web/API/DocumentFragment).
Currently Jadelet requires a single root element (e.g., HTML element) in the template.
However, there are cases where HTML root element can be redundant, or might produce invalid HTML.
For example, there might be a case where we would like to output the content in the existing `<ul>` element.

With this PR, we would be able to use a (reserved) word "Fragment" or a symbol `<>` in the template string.

```coffeescript
var template = """
Fragment
  li 1
  li 2
  li 3
"""

var template = """
<>
  li 1
  li 2
  li 3
"""
```